### PR TITLE
Small Makefile fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ The following people have contributed to this repository:
 
 Justin Cormack <justin@specialbusservice.com>
 Antti Kantee <pooka@iki.fi>
+Stephan Renatus <stephan.renatus@aisec.fraunhofer.de>

--- a/Makefile
+++ b/Makefile
@@ -164,19 +164,16 @@ $(foreach util,${NBUTILS},$(eval $(call NBUTIL_templ,${util},$(notdir ${util})))
 
 INSTALL_PATH=${PWD}
 
-${OBJDIR}:
-		mkdir -p $@
-
 ${NBCC}:	cc.in rump/lib/rump-cc.specs rump/lib/ld
-		cat $< | sed "s|@PATH@|${INSTALL_PATH}|g" > $@
+		sed "s|@PATH@|${INSTALL_PATH}|g" $< > $@
 		chmod +x $@
 
-rump/lib/ld:	ld.in ${OBJDIR}
-		cat $< | sed "s|@PATH@|${PWD}|g" > $@
+rump/lib/ld:	ld.in
+		sed "s|@PATH@|${PWD}|g" $< > $@
 		chmod +x $@
 
 rump/lib/rump-cc.specs:	specs.in
-		cat $< | sed "s|@PATH@|${PWD}|g" | sed "s|@LDLIBS@|${COMPLIBS}|g" > $@
+		sed "s|@PATH@|${PWD}|g" $< | sed "s|@LDLIBS@|${COMPLIBS}|g" > $@
 
 clean: $(foreach util,${NBUTILS_BASE},clean_${util})
 		rm -f *.o *~ rump.map namespace.map fns.map all.map weakasm.map ${PROGS} ${OBJDIR}/* ${BINDIR}/* rumpremote.sh


### PR DESCRIPTION
Removed OBJDIR, so rump/lib/ld (for example) doesn't get rebuilt
because files in obj-rr/ have changed (and in turn causing everything
else to be rebuilt the next run).

Apparently, some magic that I haven't fully understood creates the
obj-rr/ dir now.

(While doing that, saved two^Wthree cats.)

It's still running on my machine, but I guess that's a good sign.