### PR TITLE
Clang support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ The following people have contributed to this repository:
 Justin Cormack <justin@specialbusservice.com>
 Antti Kantee <pooka@iki.fi>
 Stephan Renatus <stephan.renatus@aisec.fraunhofer.de>
+Stefan Grundmann <sg2342@googlemail.com>

--- a/Makefile
+++ b/Makefile
@@ -164,11 +164,11 @@ $(foreach util,${NBUTILS},$(eval $(call NBUTIL_templ,${util},$(notdir ${util})))
 
 INSTALL_PATH=${PWD}
 
-${NBCC}:	cc.in rump/lib/rump-cc.specs rump/lib/ld
+${NBCC}:	cc.in rump/lib/rump-cc.specs rump/lib/ld.rump
 		sed "s|@PATH@|${INSTALL_PATH}|g" $< > $@
 		chmod +x $@
 
-rump/lib/ld:	ld.in
+rump/lib/ld.rump:	ld.in
 		sed "s|@PATH@|${PWD}|g" $< > $@
 		chmod +x $@
 

--- a/buildnb.sh
+++ b/buildnb.sh
@@ -79,10 +79,6 @@ done
 [ ! -f ./buildrump.sh/subr.sh ] && git submodule update --init buildrump.sh
 . ./buildrump.sh/subr.sh
 
-if ! ${CC:-cc} --version | grep -q 'Free Software Foundation'; then
-	die 'rumprun-posix currently requires CC=gcc'
-fi
-
 ${MAKE} --version | grep -q 'GNU Make' \
     || die GNU Make required, '$MAKE' "(${MAKE})" is not
 

--- a/cc.in
+++ b/cc.in
@@ -5,7 +5,9 @@ case " $* " in
 esac
 if ! ${REALCC:-cc} --version | grep -q 'Free Software Foundation'; then
 	export PATH=@PATH@/rump/lib:$PATH
-	exec "${REALCC:-cc}" -v -nostdinc -D__NetBSD__ -U__FreeBSD__ -Ulinux -U__linux -U__linux__ -U__gnu_linux__ -isystem @PATH@/rump/include  -fuse-ld=rump -nostdlib "$@"
+	exec "${REALCC:-cc}" -nostdinc -D__NetBSD__ -U__FreeBSD__ -Ulinux \
+		-U__linux -U__linux__ -U__gnu_linux__ -isystem @PATH@/rump/include \
+		-fuse-ld=rump -nostdlib "$@"
 else
 	exec "${REALCC:-cc}" "$@" -specs "@PATH@/rump/lib/rump-cc.specs"
 fi

--- a/cc.in
+++ b/cc.in
@@ -3,4 +3,9 @@ set -e
 case " $* " in
 *" -v "*)   set -x ;;
 esac
-exec "${REALCC:-cc}" "$@" -specs "@PATH@/rump/lib/rump-cc.specs"
+if ! ${REALCC:-cc} --version | grep -q 'Free Software Foundation'; then
+	export PATH=@PATH@/rump/lib:$PATH
+	exec "${REALCC:-cc}" -v -nostdinc -D__NetBSD__ -U__FreeBSD__ -Ulinux -U__linux -U__linux__ -U__gnu_linux__ -isystem @PATH@/rump/include  -fuse-ld=rump -nostdlib "$@"
+else
+	exec "${REALCC:-cc}" "$@" -specs "@PATH@/rump/lib/rump-cc.specs"
+fi

--- a/specs.in
+++ b/specs.in
@@ -7,7 +7,7 @@
 %(cc1_cpu) -nostdinc -isystem @PATH@/rump/include -isystem include%s
 
 *linker:
-@PATH@/rump/lib/ld --stunt-intermediate %g.link1 %g.link2
+@PATH@/rump/lib/ld.rump --stunt-intermediate %g.link1 %g.link2
 
 *link:
 -nostdlib %s


### PR DESCRIPTION
tested on: FreeBSD 11.0-CURRENT #0 r281196: amd64

will also work on FreeBSD 10-STABLE r279302 or later

does also work on earlier FreeBSD version with lang/clang36 from ports (CC and REALCC needs to be set to /usr/local/bin/clang36 in this case)



