### PR TITLE
use flags from rumptools/toolchain-conf.mk (for cc.in, spec.in)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 include config.mk
+include rumptools/toolchain-conf.mk
 
 OBJDIR=	obj-rr
 
@@ -173,15 +174,19 @@ $(foreach util,${NBUTILS},$(eval $(call NBUTIL_templ,${util},$(notdir ${util})))
 INSTALL_PATH=${PWD}
 
 ${NBCC}:	cc.in rump/lib/rump-cc.specs rump/lib/ld.rump
-		sed "s|@PATH@|${INSTALL_PATH}|g" $< > $@
+		sed -e "s|@PATH@|${INSTALL_PATH}|g" \
+		    -e "s|@BUILDRUMP_TOOL_CPPFLAGS@|${BUILDRUMP_TOOL_CPPFLAGS}|g" \
+		    -e "s|@BUILDRUMP_TOOL_CFLAGS@|${BUILDRUMP_TOOL_CFLAGS}|g" $< > $@
 		chmod +x $@
 
 rump/lib/ld.rump:	ld.in
-		sed "s|@PATH@|${PWD}|g" $< > $@
+		sed "s|@PATH@|${INSTALL_PATH}|g" $< > $@
 		chmod +x $@
 
 rump/lib/rump-cc.specs:	specs.in
-		sed "s|@PATH@|${PWD}|g" $< | sed "s|@LDLIBS@|${COMPLIBS}|g" > $@
+		sed -e "s|@BUILDRUMP_TOOL_CPPFLAGS@|${BUILDRUMP_TOOL_CPPFLAGS}|g" \
+		    -e "s|@BUILDRUMP_TOOL_CFLAGS@|${BUILDRUMP_TOOL_CFLAGS}|g" \
+		    -e "s|@PATH@|${INSTALL_PATH}|g" $< > $@
 
 clean: $(foreach util,${NBUTILS_BASE},clean_${util})
 		rm -f *.o *~ rump.map namespace.map fns.map all.map weakasm.map ${PROGS} ${OBJDIR}/* ${BINDIR}/* rumpremote.sh

--- a/cc.in
+++ b/cc.in
@@ -5,9 +5,10 @@ case " $* " in
 esac
 if ! ${REALCC:-cc} --version | grep -q 'Free Software Foundation'; then
 	export PATH=@PATH@/rump/lib:$PATH
-	exec "${REALCC:-cc}" -nostdinc -D__NetBSD__ -U__FreeBSD__ -Ulinux \
-		-U__linux -U__linux__ -U__gnu_linux__ -isystem @PATH@/rump/include \
-		-fuse-ld=rump -nostdlib "$@"
+	exec "${REALCC:-cc}" \
+	     @BUILDRUMP_TOOL_CFLAGS@ \
+	     @BUILDRUMP_TOOL_CPPFLAGS@ \
+	     -fuse-ld=rump -nostdlib "$@"
 else
 	exec "${REALCC:-cc}" "$@" -specs "@PATH@/rump/lib/rump-cc.specs"
 fi

--- a/specs.in
+++ b/specs.in
@@ -1,10 +1,10 @@
 %rename cpp_options old_cpp_options
 
 *cpp_options:
--nostdinc -D__NetBSD__ -U__FreeBSD__ -Ulinux -U__linux -U__linux__ -U__gnu_linux__ -isystem @PATH@/rump/include -isystem include%s %(old_cpp_options)
+@BUILDRUMP_TOOL_CFLAGS@ @BUILDRUMP_TOOL_CPPFLAGS@ -isystem include%s %(old_cpp_options)
 
 *cc1:
-%(cc1_cpu) -nostdinc -isystem @PATH@/rump/include -isystem include%s
+%(cc1_cpu) @BUILDRUMP_TOOL_CFLAGS@ @BUILDRUMP_TOOL_CPPFLAGS@
 
 *linker:
 @PATH@/rump/lib/ld.rump --stunt-intermediate %g.link1 %g.link2


### PR DESCRIPTION
while there also change the rump/lib/ld.rump target
($INSTALL_PATH instead of $PWD)

tested on
- FreeBSD 11.0-CURRENT (r281196), amd64, clang from base
- FreeBSD 11.0-CURRENT (r281196), amd64, gcc48 from ports
- Debian Jessie, amd64, gcc (Debian 4.9.2-10) 4.9.2