### PR TITLE
set LDFLAGS=-Wl,-r for .ro targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ weakasm.map:	${RUMPSRC}/lib/libc/sys/Makefile.inc ${RUMPMAKE}
 define NBUTIL_templ
 rumpobj/${1}/${2}.ro:
 	( cd ${RUMPSRC}/${1} && ${RUMPMAKE} obj && \
-	    ${RUMPMAKE} LIBCRT0= BUILDRUMP_CFLAGS="-fPIC -std=gnu99 -D__NetBSD__ ${CPPFLAGS.${2}}" ${2}.ro )
+	    ${RUMPMAKE} LDFLAGS=-Wl,-r LIBCRT0= BUILDRUMP_CFLAGS="-fPIC -std=gnu99 -D__NetBSD__ ${CPPFLAGS.${2}}" ${2}.ro )
 
 NBLIBS.${2}:= $(shell cd ${RUMPSRC}/${1} && ${RUMPMAKE} -V '$${LDADD}' | sed 's/-L\S*//g')
 LIBS.${2}=$${NBLIBS.${2}:-l%=rump/lib/lib%.a}


### PR DESCRIPTION
at least Debian clang versions 3.4.2-13 and 3.5.0-10 do not
pass the -r flag to the linker: do it explicit.

tested on
- FreeBSD 11.0-CURRENT (r281196), amd64, FreeBSD clang version 3.6.0
- FreeBSD 11.0-CURRENT (r281196), amd64, gcc48 (FreeBSD Ports Collection) 4.8.4
- Debian Jessie, amd64, gcc (Debian 4.9.2-10) 4.9.2

fixes the build for
- Debian Jessie, amd64, Debian clang version 3.5.0-10

build breaks later (due to missing -fuse_ld support) on
- Debian Jessie, amd64, Debian clang version 3.4.2-13
- FreeBSD 10.1-RELEASE-p9, amd64, FreeBSD clang version 3.4.1

this should fix #11